### PR TITLE
Use pump() instead of pipe()

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "hyperdiscovery": "^1.2.0",
     "media-recorder-stream": "^2.1.1",
     "on-load": "^3.2.0",
+    "pump": "^1.0.2",
     "webm-cluster-stream": "^1.0.0"
   },
   "repository": {


### PR DESCRIPTION
Changing to pump() allows all of the necessary streams to close properly.
Addresses https://github.com/mafintosh/hypervision/issues/15

Everything is also closed properly after user finishes viewing a stream.
