### PR TITLE
application window as video input

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -99,15 +99,8 @@ module.exports = function (state, emit) {
         devices.forEach(function (device) {
           var kind = device.kind
 
-          if (kind === 'videoinput') videoDevices.push(device)
+          if (kind === 'videoinput' || kind === 'screen') videoDevices.push(device)
           if (kind === 'audioinput') audioDevices.push(device)
-        })
-
-        // add a screen share video input to list
-        videoDevices.push({
-          deviceId: 'screen',
-          kind: 'screen',
-          label: 'Screen share'
         })
 
         emit('sourcesAvailable', {

--- a/lib/broadcast.js
+++ b/lib/broadcast.js
@@ -1,7 +1,6 @@
 var recorder = require('media-recorder-stream')
 var hypercore = require('hypercore')
 var hyperdiscovery = require('hyperdiscovery')
-var desktopCapturer = require('electron').desktopCapturer
 var cluster = require('webm-cluster-stream')
 var pump = require('pump')
 

--- a/lib/media-devices.js
+++ b/lib/media-devices.js
@@ -1,3 +1,5 @@
+var desktopCapturer = require('electron').desktopCapturer
+
 module.exports = {
   get: get,
   start: start,
@@ -6,12 +8,25 @@ module.exports = {
 
 // get list of media inputs connected to computer
 function get (done) {
-  navigator.mediaDevices.enumerateDevices()
-  .then(function (devices) {
-    done(null, devices)
-  })
-  .catch(function (err) {
-    done(err)
+  desktopCapturer.getSources({types: ['window', 'screen']}, (err, sources) => {
+    navigator.mediaDevices.enumerateDevices()
+    .then(function (devices) {
+      
+      // Treat the screen capture sources as media devices
+      sources.forEach(function (source) {
+        source.label = source.name
+        if (source.label.length > 26) {
+          source.label =  source.label.substr(0, 26)+'...'
+        }
+        source.kind = 'screen'
+        devices.push(source)
+      })
+      
+      done(null, devices)
+    })
+    .catch(function (err) {
+      done(err)
+    })
   })
 }
 
@@ -25,7 +40,8 @@ function start (videoDevice, audioDevice, cb) {
       videoOpts = {
         video: {
           mandatory: {
-            chromeMediaSource: 'screen',
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: videoDevice.id,
             maxWidth: 1920,
             maxHeight: 1080,
             maxFrameRate: 25


### PR DESCRIPTION
Capture for individual windows is now in the videoDevices selector, as well as the entire screen.

#14 